### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-dependabot.yml
+++ b/.github/workflows/validate-dependabot.yml
@@ -12,6 +12,9 @@ on:
       - '.github/dependabot.yml'
       - '.yamllint.yml'
 
+permissions:
+  contents: read
+
 jobs:
   yamllint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/SmolSoftBoi/pattern-generator/security/code-scanning/1](https://github.com/SmolSoftBoi/pattern-generator/security/code-scanning/1)

Add an explicit `permissions` block to the workflow, using least privilege.  
For this workflow, the best fix is to set workflow-level permissions to:

- `contents: read`

This is sufficient for `actions/checkout` and linting operations, and does not change functional behavior.  
Edit `.github/workflows/validate-dependabot.yml` by inserting the `permissions` block near the top level (after `on:` triggers and before `jobs:` is a clear location). No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Set workflow-level GitHub Actions permissions to read-only contents for the Dependabot validation workflow.